### PR TITLE
refactored the ncch class into 2 classes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -174,6 +174,7 @@ set(SRCS
             memory.cpp
             perf_stats.cpp
             settings.cpp
+            loader/ncsd.cpp
             )
 
 set(HEADERS
@@ -357,6 +358,7 @@ set(HEADERS
             loader/elf.h
             loader/loader.h
             loader/ncch.h
+            loader/ncsd.h
             loader/smdh.h
             tracer/recorder.h
             tracer/citrace.h

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -10,6 +10,7 @@
 #include "core/loader/3dsx.h"
 #include "core/loader/elf.h"
 #include "core/loader/ncch.h"
+#include "core/loader/ncsd.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -32,6 +33,7 @@ FileType IdentifyFile(FileUtil::IOFile& file) {
     CHECK_TYPE(THREEDSX)
     CHECK_TYPE(ELF)
     CHECK_TYPE(NCCH)
+    CHECK_TYPE(NCSD)
 
 #undef CHECK_TYPE
 
@@ -110,10 +112,13 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileUtil::IOFile&& file, FileTyp
     case FileType::ELF:
         return std::make_unique<AppLoader_ELF>(std::move(file), filename);
 
-    // NCCH/NCSD container formats.
+    // NCCH container format.
     case FileType::CXI:
-    case FileType::CCI:
         return std::make_unique<AppLoader_NCCH>(std::move(file), filepath);
+
+    // NCSD container format.
+    case FileType::CCI:
+        return std::make_unique<AppLoader_NCSD>(std::move(file), filepath);
 
     default:
         return nullptr;

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -108,11 +108,8 @@ static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decom
 FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
     u32 magic;
     file.Seek(0x100, SEEK_SET);
-    if (1 != file.ReadArray<u32>(&magic, 1))
+    if (file.ReadArray<u32>(&magic, 1) != 1)
         return FileType::Error;
-
-    if (MakeMagic('N', 'C', 'S', 'D') == magic)
-        return FileType::CCI;
 
     if (MakeMagic('N', 'C', 'C', 'H') == magic)
         return FileType::CXI;
@@ -246,22 +243,14 @@ ResultStatus AppLoader_NCCH::LoadExeFS() {
     if (!file.IsOpen())
         return ResultStatus::Error;
 
-    // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
+    // Reset read pointer to ncch_offset in case this file has been read before.
+    file.Seek(ncch_offset, SEEK_SET);
 
     if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
         return ResultStatus::Error;
 
-    // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
-    if (MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-        LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
-        ncch_offset = 0x4000;
-        file.Seek(ncch_offset, SEEK_SET);
-        file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
-    }
-
     // Verify we are loading the correct file type...
-    if (MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
+    if (ncch_header.magic != MakeMagic('N', 'C', 'C', 'H'))
         return ResultStatus::ErrorInvalidFormat;
 
     // Read ExHeader...

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -159,7 +159,7 @@ static_assert(sizeof(ExHeader_Header) == 0x800, "ExHeader structure size is wron
 namespace Loader {
 
 /// Loads an NCCH file (e.g. from a CCI, or the first NCCH in a CXI)
-class AppLoader_NCCH final : public AppLoader {
+class AppLoader_NCCH : public AppLoader {
 public:
     AppLoader_NCCH(FileUtil::IOFile&& file, const std::string& filepath)
         : AppLoader(std::move(file)), filepath(filepath) {}
@@ -223,12 +223,6 @@ private:
      */
     ResultStatus LoadExec();
 
-    /**
-     * Ensure ExeFS is loaded and ready for reading sections
-     * @return ResultStatus result of function
-     */
-    ResultStatus LoadExeFS();
-
     /// Reads the region lockout info in the SMDH and send it to CFG service
     void ParseRegionLockoutInfo();
 
@@ -242,14 +236,21 @@ private:
     u32 core_version = 0;
     u8 priority = 0;
     u8 resource_limit_category = 0;
-    u32 ncch_offset = 0; // Offset to NCCH header, can be 0 or after NCSD header
+
     u32 exefs_offset = 0;
 
-    NCCH_Header ncch_header;
     ExeFs_Header exefs_header;
     ExHeader_Header exheader_header;
 
+protected:
     std::string filepath;
+    u32 ncch_offset = 0; ///< Offset to NCCH header, can be 0 or an offset inside the file
+    NCCH_Header ncch_header;
+    /**
+     * Ensure ExeFS is loaded and ready for reading sections
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus LoadExeFS();
 };
 
 } // namespace Loader

--- a/src/core/loader/ncsd.cpp
+++ b/src/core/loader/ncsd.cpp
@@ -1,0 +1,35 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <common/logging/log.h>
+#include "ncsd.h"
+namespace Loader {
+FileType AppLoader_NCSD::IdentifyType(FileUtil::IOFile& file) {
+    u32 magic;
+    file.Seek(0x100, SEEK_SET);
+    if (file.ReadArray<u32>(&magic, 1) != 1)
+        return FileType::Error;
+
+    if (MakeMagic('N', 'C', 'S', 'D') == magic)
+        return FileType::CCI;
+
+    return FileType::Error;
+}
+ResultStatus AppLoader_NCSD::LoadExeFS() {
+    // Reset read pointer in case this file has been read before.
+    file.Seek(0, SEEK_SET);
+
+    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
+        return ResultStatus::Error;
+
+    // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
+    if (ncch_header.magic == MakeMagic('N', 'C', 'S', 'D')) {
+        LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
+        ncch_offset = 0x4000;
+        file.Seek(ncch_offset, SEEK_SET);
+        file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
+    }
+    return AppLoader_NCCH::LoadExeFS();
+}
+}

--- a/src/core/loader/ncsd.h
+++ b/src/core/loader/ncsd.h
@@ -1,0 +1,28 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "ncch.h"
+namespace Loader {
+
+class AppLoader_NCSD final : public AppLoader_NCCH {
+public:
+    AppLoader_NCSD(FileUtil::IOFile&& file, const std::string& filepath)
+        : AppLoader_NCCH(std::move(file), filepath) {}
+    /**
+   * Ensure ExeFS is loaded and ready for reading sections
+   * @return ResultStatus result of function
+   */
+    ResultStatus LoadExeFS() override;
+
+    FileType GetFileType() override {
+        return IdentifyType(file);
+    }
+    /**
+  * Returns the type of the file
+  * @param file FileUtil::IOFile open file
+  * @return FileType found, or FileType::Error if this loader doesn't know it
+  */
+    static FileType IdentifyType(FileUtil::IOFile& file);
+};
+}


### PR DESCRIPTION
the original implementation of the ncch class contained the logic for both cci files and cxi files.

this refactoring moves the logic for the cci files to its own subclass for both readability and possibly maintainability. however it does not modify the original intended function of the code. This is shown in the following screenshot
<img width="965" alt="screen shot 2017-03-28 at 2 21 33 pm" src="https://cloud.githubusercontent.com/assets/566580/24423344/3af7ce04-13c2-11e7-8032-ab33b8db5523.png">
